### PR TITLE
Added Time type to unmarshal

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func unescape(s string) string {
@@ -50,6 +51,8 @@ func unmarshal(value interface{}, data string) (err error) {
 		*v = m.(float64)
 	case *string:
 		*v = unescape(data)
+	case *time.Time:
+		*v, err = time.ParseInLocation("2006-01-02 15:04:05", data, time.UTC)
 	case *[]int:
 		if !isArray(data) {
 			//noinspection GoPlaceholderCount

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,9 +1,9 @@
 package clickhouse
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
 )
 
 func BenchmarkMarshalString(b *testing.B) {
@@ -21,6 +21,7 @@ func TestUnmarshal(t *testing.T) {
 		valInt32       int32
 		valInt64       int64
 		valString      string
+		valTime        time.Time
 		valUnsupported testing.T
 		valFloat32     float32
 		valFloat64     float64
@@ -55,6 +56,10 @@ func TestUnmarshal(t *testing.T) {
 
 	err = unmarshal(&valString, "String1\\'")
 	assert.Equal(t, "String1'", valString)
+	assert.NoError(t, err)
+
+	err = unmarshal(&valTime, "2016-10-07 19:21:17")
+	assert.Equal(t, time.Date(2016, 10, 7, 19, 21, 17, 0, time.UTC), valTime)
 	assert.NoError(t, err)
 
 	err = unmarshal(&valUnsupported, "10")


### PR DESCRIPTION
For example
```
var (
	firstTime   time.Time
	lastTime    time.Time
)
for iter.Scan(&firstTime, &lastTime) {
//
}
```